### PR TITLE
Add various items to `bitcoinsuite-core/slp`

### DIFF
--- a/bitcoinsuite-core/src/bytes.rs
+++ b/bitcoinsuite-core/src/bytes.rs
@@ -30,6 +30,12 @@ impl AsRef<[u8]> for Bytes {
     }
 }
 
+impl std::borrow::Borrow<[u8]> for Bytes {
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
 impl PartialEq for Bytes {
     fn eq(&self, other: &Self) -> bool {
         self.data.eq(&other.data)
@@ -37,6 +43,18 @@ impl PartialEq for Bytes {
 }
 
 impl Eq for Bytes {}
+
+impl PartialOrd for Bytes {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.data.partial_cmp(&other.data)
+    }
+}
+
+impl Ord for Bytes {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.data.cmp(&other.data)
+    }
+}
 
 impl Hash for Bytes {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/bitcoinsuite-core/src/script.rs
+++ b/bitcoinsuite-core/src/script.rs
@@ -87,6 +87,16 @@ impl Script {
         }
     }
 
+    pub fn p2pk_legacy(pubkey: [u8; 65]) -> Self {
+        let mut bytes = BytesMut::new();
+        bytes.put_slice(&[0x41]);
+        bytes.put_slice(&pubkey);
+        bytes.put_slice(&[0xac]);
+        Script {
+            bytecode: bytes.freeze(),
+        }
+    }
+
     pub fn p2pkh(hash: &ShaRmd160) -> Self {
         let mut bytes = BytesMut::new();
         bytes.put_slice(&[0x76, 0xa9, 0x14]);

--- a/bitcoinsuite-core/src/tx.rs
+++ b/bitcoinsuite-core/src/tx.rs
@@ -18,7 +18,7 @@ pub struct Tx {
     raw: Bytes,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
 pub struct OutPoint {
     pub txid: Sha256d,
     pub out_idx: u32,

--- a/bitcoinsuite-slp/src/rich_tx.rs
+++ b/bitcoinsuite-slp/src/rich_tx.rs
@@ -12,6 +12,7 @@ pub struct RichTx {
     pub spends: Vec<Option<OutPoint>>,
     pub slp_burns: Vec<Option<Box<SlpBurn>>>,
     pub slp_error_msg: Option<String>,
+    pub time_first_seen: i64,
     pub network: Network,
 }
 
@@ -19,6 +20,7 @@ pub struct RichTx {
 pub struct RichTxBlock {
     pub height: i32,
     pub hash: Sha256d,
+    pub timestamp: i64,
 }
 
 pub struct RichTxInput<'tx> {
@@ -61,5 +63,16 @@ impl RichTx {
                 .unwrap_or_default(),
             spent_by: self.spends[idx].as_ref(),
         })
+    }
+
+    pub fn timestamp(&self) -> i64 {
+        match self.time_first_seen {
+            0 => self
+                .block
+                .as_ref()
+                .map(|block| block.timestamp)
+                .unwrap_or_default(),
+            _ => self.time_first_seen,
+        }
     }
 }


### PR DESCRIPTION
- Add `Borrow`, `PartialOrd` and `Ord` derive to Bytes
- Add `PartialOrd` and `Ord` derive to OutPoint
- Add `p2pk_legacy` to `Script`
- Add `time_first_seen` to `RichTx`
- Add `timestamp` to `RichTxBlock`