### PR TITLE
Add `test_mempool_accept` to `BitcoindRpcClient`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "bitcoinsuite-core",
  "bitcoinsuite-error",
  "bitcoinsuite-test-utils",
+ "hex",
  "json",
  "reqwest",
  "serde",

--- a/bitcoinsuite-bitcoind/Cargo.toml
+++ b/bitcoinsuite-bitcoind/Cargo.toml
@@ -12,6 +12,9 @@ bitcoinsuite-core = { path = "../bitcoinsuite-core" }
 thiserror = "1.0"
 bitcoinsuite-error = { path = "../bitcoinsuite-error" }
 
+# Hex en-/decoding
+hex = "0.4"
+
 # Config
 serde = { version = "1.0", features = ["derive"] }
 


### PR DESCRIPTION
Allows checking if a transaction is valid without actually adding it to the mempool yet.