### PR TITLE
Upgrade to include `size` and `raw_header` fields

### DIFF
--- a/bitcoinsuite-bitcoind/src/rpc_client.rs
+++ b/bitcoinsuite-bitcoind/src/rpc_client.rs
@@ -67,8 +67,7 @@ impl BitcoindRpcClient {
         cmd: &str,
         args: &[json::JsonValue],
     ) -> Result<reqwest::Response> {
-        Ok(self
-            .client
+        self.client
             .post(&self.conf.url)
             .basic_auth(&self.conf.rpc_user, Some(&self.conf.rpc_pass))
             .header(reqwest::header::CONTENT_TYPE, "text/plain")
@@ -83,7 +82,7 @@ impl BitcoindRpcClient {
             )
             .send()
             .await
-            .wrap_err(BitcoindError::Client)?)
+            .wrap_err(BitcoindError::Client)
     }
 
     pub(crate) async fn cmd_handle_error(response: reqwest::Response) -> Result<json::JsonValue> {

--- a/bitcoinsuite-chronik-client/proto/chronik.proto
+++ b/bitcoinsuite-chronik-client/proto/chronik.proto
@@ -43,6 +43,7 @@ message Tx {
     string slp_error_msg = 7;
     BlockMetadata block = 8;
     int64 time_first_seen = 9;
+    uint32 size = 11;
     Network network = 10;
 }
 
@@ -95,6 +96,7 @@ message BlockDetails {
 message Block {
     BlockInfo block_info = 1;
     BlockDetails block_details = 3;
+    bytes raw_header = 4;
     repeated Tx txs = 2;
 }
 

--- a/bitcoinsuite-chronik-client/tests/test_chronik_client.rs
+++ b/bitcoinsuite-chronik-client/tests/test_chronik_client.rs
@@ -213,6 +213,7 @@ pub async fn test_tx() -> Result<()> {
             timestamp: 1_624_249_618,
         }),
         time_first_seen: 0,
+        size: 225,
         network: proto::Network::Xpi as i32,
     };
     assert_eq!(actual_tx, expected_tx);


### PR DESCRIPTION
Upgrade `bitcoinsuite-chronik-client` to include the new `Tx.size` and `Block.raw_header` fields.