### PR TITLE
Add `is_coinbase` to `Tx` for Chronik

### DIFF
--- a/bitcoinsuite-chronik-client/proto/chronik.proto
+++ b/bitcoinsuite-chronik-client/proto/chronik.proto
@@ -44,6 +44,7 @@ message Tx {
     BlockMetadata block = 8;
     int64 time_first_seen = 9;
     uint32 size = 11;
+    bool is_coinbase = 12;
     Network network = 10;
 }
 

--- a/bitcoinsuite-chronik-client/tests/test_chronik_client.rs
+++ b/bitcoinsuite-chronik-client/tests/test_chronik_client.rs
@@ -239,6 +239,7 @@ pub async fn test_tx() -> Result<()> {
         }),
         time_first_seen: 0,
         size: 225,
+        is_coinbase: false,
         network: proto::Network::Xpi as i32,
     };
     assert_eq!(actual_tx, expected_tx);


### PR DESCRIPTION
Determines whether the tx is a coinbase tx.