### PR TITLE
Upgrade `bitcoinsuite-chronik-client` Token proto

### DIFF
--- a/bitcoinsuite-chronik-client/proto/chronik.proto
+++ b/bitcoinsuite-chronik-client/proto/chronik.proto
@@ -61,6 +61,11 @@ message Utxo {
 message Token {
     SlpTxData slp_tx_data = 1;
     TokenStats token_stats = 2;
+    BlockMetadata block = 3;
+    int64 time_first_seen = 4;
+    uint64 initial_token_quantity = 5;
+    bool contains_baton = 6;
+    Network network = 7;
 }
 
 message BlockInfo {

--- a/bitcoinsuite-chronik-client/tests/test_chronik_client.rs
+++ b/bitcoinsuite-chronik-client/tests/test_chronik_client.rs
@@ -290,6 +290,20 @@ pub async fn test_token() -> Result<()> {
     let token_stats = token.token_stats.unwrap();
     assert!(!token_stats.total_minted.is_empty());
     assert!(!token_stats.total_burned.is_empty());
+    let block_hash =
+        Sha256d::from_hex_be("00000000000000002686aa5ffa8401c7ed67338fb9475561b2fa9817d6571da8")?;
+    assert_eq!(
+        token.block,
+        Some(proto::BlockMetadata {
+            hash: block_hash.as_slice().to_vec(),
+            height: 697721,
+            timestamp: 1627783243,
+        }),
+    );
+    assert_eq!(token.time_first_seen, 0);
+    assert_eq!(token.initial_token_quantity, 0);
+    assert_eq!(token.contains_baton, true);
+    assert_eq!(token.network, proto::Network::Xec.into());
     Ok(())
 }
 


### PR DESCRIPTION
This adds the fields `block`, `time_first_seen`, `initial_token_quantity`, `contains_baton`, `network` to `Token` proto.