### PR TITLE
Add and use consts for opcodes

### DIFF
--- a/bitcoinsuite-core/src/build_block.rs
+++ b/bitcoinsuite-core/src/build_block.rs
@@ -1,5 +1,5 @@
 use crate::{
-    lotus_txid, BitcoinBlock, BitcoinHeader, Bytes, BytesMut, LotusBlock, LotusHeader,
+    lotus_txid, opcode::*, BitcoinBlock, BitcoinHeader, Bytes, BytesMut, LotusBlock, LotusHeader,
     LotusMetadataField, OutPoint, Script, SequenceNo, Sha256d, Tx, TxInput, TxOutput, UnhashedTx,
 };
 
@@ -63,7 +63,7 @@ pub fn build_lotus_coinbase(height: i32, script: Script) -> UnhashedTx {
     let opreturn = match height {
         0 => Script::from_static_slice(b"\x05logos\0"),
         1..=16 => Script::new(
-            [[0x6a].as_ref(), b"\x05logos", &[height as u8 + 0x50]]
+            [[OP_RETURN].as_ref(), b"\x05logos", &[height as u8 + 0x50]]
                 .concat()
                 .into(),
         ),

--- a/bitcoinsuite-core/src/lib.rs
+++ b/bitcoinsuite-core/src/lib.rs
@@ -13,6 +13,7 @@ mod hash;
 mod merkle;
 mod network;
 mod op;
+pub mod opcode;
 mod script;
 mod sequence;
 mod sighashtype;

--- a/bitcoinsuite-core/src/opcode.rs
+++ b/bitcoinsuite-core/src/opcode.rs
@@ -1,0 +1,146 @@
+// push value
+pub const OP_0: u8 = 0x00;
+pub const OP_FALSE: u8 = OP_0;
+pub const OP_PUSHDATA1: u8 = 0x4c;
+pub const OP_PUSHDATA2: u8 = 0x4d;
+pub const OP_PUSHDATA4: u8 = 0x4e;
+pub const OP_1NEGATE: u8 = 0x4f;
+pub const OP_RESERVED: u8 = 0x50;
+pub const OP_1: u8 = 0x51;
+pub const OP_TRUE: u8 = OP_1;
+pub const OP_2: u8 = 0x52;
+pub const OP_3: u8 = 0x53;
+pub const OP_4: u8 = 0x54;
+pub const OP_5: u8 = 0x55;
+pub const OP_6: u8 = 0x56;
+pub const OP_7: u8 = 0x57;
+pub const OP_8: u8 = 0x58;
+pub const OP_9: u8 = 0x59;
+pub const OP_10: u8 = 0x5a;
+pub const OP_11: u8 = 0x5b;
+pub const OP_12: u8 = 0x5c;
+pub const OP_13: u8 = 0x5d;
+pub const OP_14: u8 = 0x5e;
+pub const OP_15: u8 = 0x5f;
+pub const OP_16: u8 = 0x60;
+
+// control
+pub const OP_NOP: u8 = 0x61;
+pub const OP_SCRIPTTYPE: u8 = 0x62; // Lotus only
+pub const OP_IF: u8 = 0x63;
+pub const OP_NOTIF: u8 = 0x64;
+pub const OP_VERIF: u8 = 0x65;
+pub const OP_VERNOTIF: u8 = 0x66;
+pub const OP_ELSE: u8 = 0x67;
+pub const OP_ENDIF: u8 = 0x68;
+pub const OP_VERIFY: u8 = 0x69;
+pub const OP_RETURN: u8 = 0x6a;
+
+// stack ops
+pub const OP_TOALTSTACK: u8 = 0x6b;
+pub const OP_FROMALTSTACK: u8 = 0x6c;
+pub const OP_2DROP: u8 = 0x6d;
+pub const OP_2DUP: u8 = 0x6e;
+pub const OP_3DUP: u8 = 0x6f;
+pub const OP_2OVER: u8 = 0x70;
+pub const OP_2ROT: u8 = 0x71;
+pub const OP_2SWAP: u8 = 0x72;
+pub const OP_IFDUP: u8 = 0x73;
+pub const OP_DEPTH: u8 = 0x74;
+pub const OP_DROP: u8 = 0x75;
+pub const OP_DUP: u8 = 0x76;
+pub const OP_NIP: u8 = 0x77;
+pub const OP_OVER: u8 = 0x78;
+pub const OP_PICK: u8 = 0x79;
+pub const OP_ROLL: u8 = 0x7a;
+pub const OP_ROT: u8 = 0x7b;
+pub const OP_SWAP: u8 = 0x7c;
+pub const OP_TUCK: u8 = 0x7d;
+
+// splice ops
+pub const OP_CAT: u8 = 0x7e;
+pub const OP_SPLIT: u8 = 0x7f; // after monolith upgrade (May 2018)
+pub const OP_NUM2BIN: u8 = 0x80; // after monolith upgrade (May 2018)
+pub const OP_BIN2NUM: u8 = 0x81; // after monolith upgrade (May 2018)
+pub const OP_SIZE: u8 = 0x82;
+
+// bit logic
+pub const OP_INVERT: u8 = 0x83;
+pub const OP_AND: u8 = 0x84;
+pub const OP_OR: u8 = 0x85;
+pub const OP_XOR: u8 = 0x86;
+pub const OP_EQUAL: u8 = 0x87;
+pub const OP_EQUALVERIFY: u8 = 0x88;
+pub const OP_RESERVED1: u8 = 0x89;
+pub const OP_RESERVED2: u8 = 0x8a;
+
+// numeric
+pub const OP_1ADD: u8 = 0x8b;
+pub const OP_1SUB: u8 = 0x8c;
+pub const OP_2MUL: u8 = 0x8d;
+pub const OP_2DIV: u8 = 0x8e;
+pub const OP_NEGATE: u8 = 0x8f;
+pub const OP_ABS: u8 = 0x90;
+pub const OP_NOT: u8 = 0x91;
+pub const OP_0NOTEQUAL: u8 = 0x92;
+
+pub const OP_ADD: u8 = 0x93;
+pub const OP_SUB: u8 = 0x94;
+pub const OP_MUL: u8 = 0x95;
+pub const OP_DIV: u8 = 0x96;
+pub const OP_MOD: u8 = 0x97;
+pub const OP_RAWLEFTBITSHIFT: u8 = 0x98; // Lotus only
+pub const OP_MULPOW2: u8 = 0x99; // Lotus only
+
+pub const OP_BOOLAND: u8 = 0x9a;
+pub const OP_BOOLOR: u8 = 0x9b;
+pub const OP_NUMEQUAL: u8 = 0x9c;
+pub const OP_NUMEQUALVERIFY: u8 = 0x9d;
+pub const OP_NUMNOTEQUAL: u8 = 0x9e;
+pub const OP_LESSTHAN: u8 = 0x9f;
+pub const OP_GREATERTHAN: u8 = 0xa0;
+pub const OP_LESSTHANOREQUAL: u8 = 0xa1;
+pub const OP_GREATERTHANOREQUAL: u8 = 0xa2;
+pub const OP_MIN: u8 = 0xa3;
+pub const OP_MAX: u8 = 0xa4;
+
+pub const OP_WITHIN: u8 = 0xa5;
+
+// crypto
+pub const OP_RIPEMD160: u8 = 0xa6;
+pub const OP_SHA1: u8 = 0xa7;
+pub const OP_SHA256: u8 = 0xa8;
+pub const OP_HASH160: u8 = 0xa9;
+pub const OP_HASH256: u8 = 0xaa;
+pub const OP_CODESEPARATOR: u8 = 0xab;
+pub const OP_CHECKSIG: u8 = 0xac;
+pub const OP_CHECKSIGVERIFY: u8 = 0xad;
+pub const OP_CHECKMULTISIG: u8 = 0xae;
+pub const OP_CHECKMULTISIGVERIFY: u8 = 0xaf;
+
+// expansion
+pub const OP_NOP1: u8 = 0xb0;
+pub const OP_CHECKLOCKTIMEVERIFY: u8 = 0xb1;
+pub const OP_NOP2: u8 = OP_CHECKLOCKTIMEVERIFY;
+pub const OP_CHECKSEQUENCEVERIFY: u8 = 0xb2;
+pub const OP_NOP3: u8 = OP_CHECKSEQUENCEVERIFY;
+pub const OP_NOP4: u8 = 0xb3;
+pub const OP_NOP5: u8 = 0xb4;
+pub const OP_NOP6: u8 = 0xb5;
+pub const OP_NOP7: u8 = 0xb6;
+pub const OP_NOP8: u8 = 0xb7;
+pub const OP_NOP9: u8 = 0xb8;
+pub const OP_NOP10: u8 = 0xb9;
+
+// More crypto
+pub const OP_CHECKDATASIG: u8 = 0xba;
+pub const OP_CHECKDATASIGVERIFY: u8 = 0xbb;
+
+// additional byte string operations
+pub const OP_REVERSEBYTES: u8 = 0xbc;
+
+// multi-byte opcodes
+pub const OP_PREFIX_BEGIN: u8 = 0xf0;
+pub const OP_PREFIX_END: u8 = 0xf7;
+
+pub const OP_INVALIDOPCODE: u8 = 0xff;


### PR DESCRIPTION
Currently, we use hardcoded values. Now all the opcodes are defined, and we use them where appropriate.