### PR TITLE
Expose `ChronikClient::ws_url`; update prost dependency

### DIFF
--- a/bitcoinsuite-chronik-client/Cargo.toml
+++ b/bitcoinsuite-chronik-client/Cargo.toml
@@ -17,14 +17,14 @@ reqwest = "0.11"
 tokio = { version = "1.14", features = ["full"] }
 
 # Protobuf (de)serialization
-prost = "0.10"
+prost = "0.11"
 
 # Hex en-/decoding
 hex = "0.4"
 
 [build-dependencies]
 # Build Protobuf structs
-prost-build = "0.10"
+prost-build = "0.11"
 
 [dev-dependencies]
 # Colorful diffs for assertions

--- a/bitcoinsuite-chronik-client/src/lib.rs
+++ b/bitcoinsuite-chronik-client/src/lib.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 #[derive(Debug, Clone)]
 pub struct ChronikClient {
     http_url: String,
-    _ws_url: String,
+    ws_url: String,
     client: reqwest::Client,
 }
 
@@ -82,9 +82,13 @@ impl ChronikClient {
         let ws_url = ws_url + "/ws";
         Ok(ChronikClient {
             http_url: url,
-            _ws_url: ws_url,
+            ws_url,
             client: reqwest::Client::new(),
         })
+    }
+
+    pub fn ws_url(&self) -> &str {
+        &self.ws_url
     }
 
     pub async fn broadcast_tx(&self, raw_tx: Vec<u8>) -> Result<proto::BroadcastTxResponse> {


### PR DESCRIPTION
There's no good WS client yet for Rust; so we at least expose the ws_url. We also update the prost dependency.