### PR TITLE
Remove `OutputsExceedInputs` when using `TxBuilder`

### DIFF
--- a/bitcoinsuite-core/src/sign/error.rs
+++ b/bitcoinsuite-core/src/sign/error.rs
@@ -24,8 +24,6 @@ pub enum SignError {
     InvalidScriptEncoding,
     #[error("Multiple leftover outputs not supported")]
     MultipleLeftover,
-    #[error("Outputs ({output_sum}) exceed inputs ({input_sum})")]
-    OutputsExceedInputs { output_sum: i64, input_sum: i64 },
     #[error("Inputs ({input_sum}) can only pay for {max_fee} fees, but {required_fee} required")]
     InsufficientInputsForFee {
         input_sum: i64,


### PR DESCRIPTION
Some txs we sign (SLP Postage) don't have enough inputs (yet). We remove this check so we can sign these kinds of txs.