### PR TITLE
replace echo with printf to get \n instead of '\n'

### DIFF
--- a/bitcoinsuite-bitcoind-nng/make-fb.sh
+++ b/bitcoinsuite-bitcoind-nng/make-fb.sh
@@ -1,3 +1,3 @@
 flatc -o src --rust flatbuffers/nng_interface.fbs
 
-echo "#![allow(unused_imports, dead_code, clippy::all)]\n$(cat src/nng_interface_generated.rs)" > src/nng_interface_generated.rs
+printf "#![allow(unused_imports, dead_code, clippy::all)]\n$(cat src/nng_interface_generated.rs)" > src/nng_interface_generated.rs


### PR DESCRIPTION
cloned, ran cargo make, and rustc was yelling at me over this:

```
error: unknown start of token: \
 --> bitcoinsuite-bitcoind-nng/src/nng_interface_generated.rs:1:50
  |
1 | #![allow(unused_imports, dead_code, clippy::all)]\n// automatically
  generated by the FlatBuffers compiler, do not modify
  |                                                  ^

error: expected one of `!` or `::`, found keyword `use`
 --> bitcoinsuite-bitcoind-nng/src/nng_interface_generated.rs:6:1
  |
1 | #![allow(unused_imports, dead_code, clippy::all)]\n// automatically
  generated by the FlatBuffers compiler, do not modify
  |
```